### PR TITLE
Quick change to previous commit - broken link fixed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ The folder structure is as follows:
   <img src="https://contrib.rocks/image?repo=betterseqta/betterseqta-plus" />
 </a>
 
-Want to contribute? [Click Here!](https://github.com/BetterSEQTA/BetterSEQTA-Plus/contribute.md)
+Want to contribute? [Click Here!](https://github.com/BetterSEQTA/BetterSEQTA-Plus/blob/74933a778c7b80976df0745ee9e719401f06421a/contribute.md)
 ## Credits
 
 This extension was initially developed by [Nulkem](https://github.com/Nulkem/betterseqta), was ported to manifest V3 by [MEGA-Dawg68](https://github.com/MEGA-Dawg68) and is currently under active development by [SethBurkart123](https://github.com/SethBurkart123) and [Crazypersonalph](https://github.com/Crazypersonalph)


### PR DESCRIPTION
The `https://github.com/BetterSEQTA/BetterSEQTA-Plus/contribute.md` led to the wrong page. It has been fixed in this commit.