### PR TITLE
Safari support?

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@
   - Opera Supported
   - Vivaldi Supported
   - Firefox (Experimental - available [here](https://addons.mozilla.org/en-US/firefox/addon/betterseqta-plus/)
-  - Safari (Experimental - only available via compilation)
 
 ## Creating Custom Themes
 


### PR DESCRIPTION
I see in the README that Safari support is "existent", but no new builds can get compiled. I thought to delete this line, but does it need to be kept?
