### PR TITLE
"npm run package" got removed ages ago and was replaced by "npm run zip"

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ npm run build
 3. Package it up (optional)
 
 ```
-npm run package # This requires 7-Zip to be installed in order to work
+npm run zip # This requires 7-Zip to be installed in order to work
 ```
 
 ## Folder Structure


### PR DESCRIPTION
Still requires 7-Zip.