### PR TITLE
Subject Searching in Global Search

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "flexsearch": "^0.8.147",
     "fuse.js": "^7.1.0",
     "idb": "^8.0.2",
+    "jszip": "^3.10.1",
     "localforage": "^1.10.0",
     "lodash": "^4.17.21",
     "mathjs": "^14.4.0",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "flexsearch": "^0.8.147",
     "fuse.js": "^7.1.0",
     "idb": "^8.0.2",
-    "jszip": "^3.10.1",
     "localforage": "^1.10.0",
     "lodash": "^4.17.21",
     "mathjs": "^14.4.0",

--- a/src/plugins/built-in/globalSearch/src/components/SearchBar.svelte
+++ b/src/plugins/built-in/globalSearch/src/components/SearchBar.svelte
@@ -196,6 +196,15 @@
       const result = combinedResults[resultIndex];
       if (result?.item) {
         executeItemAction(result.item);
+        if (result?.type === 'dynamic') {
+          tick().then(() => {
+            const li = resultsList?.querySelectorAll('li')[resultIndex];
+            if (li) {
+              const btn = li.querySelector('button, [tabindex="0"]');
+              if (btn) (btn as HTMLElement).click();
+            }
+          });
+        }
       }
     }
   };

--- a/src/plugins/built-in/globalSearch/src/components/items/SubjectItem.svelte
+++ b/src/plugins/built-in/globalSearch/src/components/items/SubjectItem.svelte
@@ -46,7 +46,7 @@
 >
   <div class="flex items-center w-full">
     <div class="flex-none w-8 h-8 text-xl font-IconFamily flex items-center justify-center {isSelected ? 'text-zinc-900 dark:text-white' : 'text-zinc-600 dark:text-zinc-400'}">
-      {item.metadata?.type === 'assessments' ? '\uebee' : '\uec0a'}
+      {item.metadata?.type === 'assessments' ? '\ueac3' : '\ueb4d'}
     </div>
     <span class="ml-4 text-lg truncate">
       {@html stripHtmlButKeepHighlights(highlightMatch(item.text, searchTerm, matches))}

--- a/src/plugins/built-in/globalSearch/src/components/items/SubjectItem.svelte
+++ b/src/plugins/built-in/globalSearch/src/components/items/SubjectItem.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+  import { highlightMatch, stripHtmlButKeepHighlights } from '../../utils/highlight';
+  import type { IndexItem } from '../../indexing/types';
+  import type { FuseResultMatch } from '../../core/types';
+
+  export let item: IndexItem;
+  export let isSelected: boolean;
+  export let searchTerm: string;
+  export let matches: readonly FuseResultMatch[] | undefined;
+  export let onclick: (() => void) | undefined;
+
+  function handleClick() {
+    console.log('Subject item clicked', item.metadata);
+    const { type, subjectId, programme } = item.metadata;
+    let url = '';
+    if (type === 'assessments') {
+      if (programme && subjectId) {
+        url = `/#?page=/assessments/${programme}:${subjectId}`;
+      }
+    } else {
+      if (programme && subjectId) {
+        url = `/#?page=/courses/${programme}:${subjectId}`;
+      }
+    }
+    console.log('Navigating to:', url, { type, subjectId, programme });
+    if (url) {
+      try {
+        window.location.assign(url);
+        // Fallback in case assign is blocked
+        setTimeout(() => {
+          if (window.location.hash !== url.replace(/^.*#/, '')) {
+            window.location.href = url;
+          }
+        }, 200);
+      } catch (e) {
+        window.location.href = url;
+      }
+    }
+  }
+</script>
+
+<button
+  class="w-full flex flex-col px-2 py-1.5 rounded-lg select-none cursor-pointer group transition-colors duration-100
+  {isSelected ? 'bg-zinc-900/5 dark:bg-white/10 text-zinc-900 dark:text-white' : 'hover:bg-zinc-500/5 dark:hover:bg-white/5 text-zinc-800 dark:text-zinc-200'}"
+  on:click={() => { handleClick(); if (typeof onclick === 'function') onclick(); }}
+>
+  <div class="flex items-center w-full">
+    <div class="flex-none w-8 h-8 text-xl font-IconFamily flex items-center justify-center {isSelected ? 'text-zinc-900 dark:text-white' : 'text-zinc-600 dark:text-zinc-400'}">
+      {item.metadata?.type === 'assessments' ? '\uebee' : '\uec0a'}
+    </div>
+    <span class="ml-4 text-lg truncate">
+      {@html stripHtmlButKeepHighlights(highlightMatch(item.text, searchTerm, matches))}
+    </span>
+    <span class="flex-none ml-auto text-xs text-zinc-500 dark:text-zinc-400">
+      {item.metadata?.subjectCode}
+    </span>
+  </div>
+  {#if item.content}
+    <div class="mt-1 ml-12 text-sm text-zinc-600 dark:text-zinc-400 line-clamp-2 text-start">
+      {@html stripHtmlButKeepHighlights(highlightMatch(item.content, searchTerm, matches))}
+    </div>
+  {/if}
+</button> 

--- a/src/plugins/built-in/globalSearch/src/indexing/jobs.ts
+++ b/src/plugins/built-in/globalSearch/src/indexing/jobs.ts
@@ -2,9 +2,11 @@ import type { Job } from "./types";
 import { messagesJob } from "./jobs/messages";
 import { notificationsJob } from "./jobs/notifications";
 import { forumsJob } from "./jobs/forums";
+import { subjectsJob } from "./jobs/subjects";
 
 export const jobs: Record<string, Job> = {
   messages: messagesJob,
   notifications: notificationsJob,
   forums: forumsJob,
+  subjects: subjectsJob,
 };

--- a/src/plugins/built-in/globalSearch/src/indexing/jobs/subjects.ts
+++ b/src/plugins/built-in/globalSearch/src/indexing/jobs/subjects.ts
@@ -1,0 +1,116 @@
+import type { Job, IndexItem } from "../types";
+
+const fetchSubjects = async () => {
+  const res = await fetch(`${location.origin}/seqta/student/load/subjects`, {
+    method: "POST",
+    credentials: "include",
+    headers: { "Content-Type": "application/json; charset=utf-8" },
+    body: JSON.stringify({ mode: "list" }),
+  });
+
+  const data = await res.json();
+  console.debug("[Subjects job] API response:", data);
+  return data;
+};
+
+export const subjectsJob: Job = {
+  id: "subjects",
+  label: "Subjects",
+  renderComponentId: "subject",
+  frequency: "pageLoad",
+
+  run: async (ctx) => {
+    const existingIds = new Set(
+      (await ctx.getStoredItems("subjects")).map((i) => i.id),
+    );
+
+    let list;
+    try {
+      list = await fetchSubjects();
+    } catch (e) {
+      console.error("[Subjects job] list fetch failed:", e);
+      return [];
+    }
+
+    if (list.status !== "200") {
+      console.error("[Subjects job] API returned non-200 status:", list.status);
+      return [];
+    }
+
+    // Check if we have the expected data structure
+    if (!list.payload || !Array.isArray(list.payload)) {
+      console.error("[Subjects job] Unexpected API response structure:", list);
+      return [];
+    }
+
+    const items: IndexItem[] = [];
+
+    // Process each semester
+    for (const semester of list.payload) {
+      if (!semester.subjects || !Array.isArray(semester.subjects)) {
+        console.warn("[Subjects job] Skipping invalid semester:", semester);
+        continue;
+      }
+
+      // Process each subject in the semester
+      for (const subject of semester.subjects) {
+        // Skip if subject doesn't have required fields
+        if (!subject || !subject.code || !subject.title) {
+          console.warn("[Subjects job] Skipping invalid subject:", subject);
+          continue;
+        }
+
+        const id = `${semester.code}-${subject.code}-${subject.metaclass}`;
+        if (existingIds.has(id)) continue;
+
+        // Create two items for each subject - one for assessments and one for course
+        items.push(
+          {
+            id: `${id}-assessments`,
+            text: `${subject.title} Assessments`,
+            category: "subjects",
+            content: `View assessments for ${subject.title} (${semester.description})`,
+            dateAdded: Date.now(),
+            metadata: {
+              subjectId: subject.metaclass,
+              subjectName: subject.title,
+              subjectCode: subject.code,
+              programme: subject.programme,
+              semesterCode: semester.code,
+              semesterDescription: semester.description,
+              type: "assessments"
+            },
+            actionId: "subject-assessments",
+            renderComponentId: "subject",
+          },
+          {
+            id: `${id}-course`,
+            text: `${subject.title} Course`,
+            category: "subjects",
+            content: `View course content for ${subject.title} (${semester.description})`,
+            dateAdded: Date.now(),
+            metadata: {
+              subjectId: subject.metaclass,
+              subjectName: subject.title,
+              subjectCode: subject.code,
+              programme: subject.programme,
+              semesterCode: semester.code,
+              semesterDescription: semester.description,
+              type: "course"
+            },
+            actionId: "subject-course",
+            renderComponentId: "subject",
+          }
+        );
+      }
+    }
+
+    console.debug(`[Subjects job] Indexed ${items.length} subject items`);
+    return items;
+  },
+
+  purge: (items) => {
+    // Keep all subjects as they are relatively static
+    return items;
+  },
+};

--- a/src/plugins/built-in/globalSearch/src/indexing/jobs/subjects.ts
+++ b/src/plugins/built-in/globalSearch/src/indexing/jobs/subjects.ts
@@ -1,4 +1,4 @@
-import type { Job, IndexItem } from "../types";
+import type { IndexItem, Job } from "../types";
 
 const fetchSubjects = async () => {
   const res = await fetch(`${location.origin}/seqta/student/load/subjects`, {

--- a/src/plugins/built-in/globalSearch/src/indexing/jobs/subjects.ts
+++ b/src/plugins/built-in/globalSearch/src/indexing/jobs/subjects.ts
@@ -63,6 +63,10 @@ export const subjectsJob: Job = {
         const id = `${semester.code}-${subject.code}-${subject.metaclass}`;
         if (existingIds.has(id)) continue;
 
+        // Extract year level from subject code (assuming format like "YEAR10" or "10ENG")
+        const yearLevel = subject.code.match(/^YEAR(\d+)|^(\d+)/i)?.[1] || subject.code.match(/^(\d+)/)?.[1] || 0;
+        const isActive = subject.active === 1;
+
         // Create two items for each subject - one for assessments and one for course
         items.push(
           {
@@ -78,7 +82,9 @@ export const subjectsJob: Job = {
               programme: subject.programme,
               semesterCode: semester.code,
               semesterDescription: semester.description,
-              type: "assessments"
+              type: "assessments",
+              yearLevel: Number(yearLevel),
+              isActive
             },
             actionId: "subject-assessments",
             renderComponentId: "subject",
@@ -96,7 +102,9 @@ export const subjectsJob: Job = {
               programme: subject.programme,
               semesterCode: semester.code,
               semesterDescription: semester.description,
-              type: "course"
+              type: "course",
+              yearLevel: Number(yearLevel),
+              isActive
             },
             actionId: "subject-course",
             renderComponentId: "subject",

--- a/src/plugins/built-in/globalSearch/src/indexing/renderComponents.ts
+++ b/src/plugins/built-in/globalSearch/src/indexing/renderComponents.ts
@@ -1,12 +1,16 @@
 import type { SvelteComponent } from "svelte";
 import AssessmentItem from "../components/items/AssessmentItem.svelte";
 import ForumItem from "../components/items/ForumItem.svelte";
+import SubjectItem from "../components/items/SubjectItem.svelte";
+import type { IndexItem } from "./types";
+import { highlightMatch } from "../utils/highlight";
 // import other components as needed
 
 export const renderComponentMap: Record<string, typeof SvelteComponent> = {
   assessment: AssessmentItem as unknown as typeof SvelteComponent,
   message: AssessmentItem as unknown as typeof SvelteComponent,
   forum: ForumItem as unknown as typeof SvelteComponent,
+  subject: SubjectItem as unknown as typeof SvelteComponent,
   // subject: SubjectComponent,
   // etc...
 };

--- a/src/plugins/built-in/globalSearch/src/indexing/types.ts
+++ b/src/plugins/built-in/globalSearch/src/indexing/types.ts
@@ -9,6 +9,7 @@ export interface IndexItem {
   metadata: Record<string, any>;
   actionId: string;
   renderComponentId: string;
+  renderComponent?: typeof SvelteComponent;
 }
 
 export type Frequency =

--- a/src/plugins/built-in/globalSearch/src/search/searchUtils.ts
+++ b/src/plugins/built-in/globalSearch/src/search/searchUtils.ts
@@ -25,15 +25,16 @@ export function createSearchIndexes() {
       { name: "content", weight: 1 },
       { name: "category", weight: 1 },
       { name: "metadata.subjectName", weight: 3 },
-      { name: "metadata.subjectCode", weight: 2 },
-      { name: "metadata.semesterDescription", weight: 1 }
+      { name: "metadata.subjectCode", weight: 2.5 },
+      { name: "metadata.semesterDescription", weight: 1 },
+      { name: "metadata.yearLevel", weight: 1.5 }
     ],
     includeScore: true,
     includeMatches: true,
-    threshold: 0.4, // Lower threshold to be more lenient
+    threshold: 0.4,
     minMatchCharLength: 2,
-    distance: 100, // Increased distance to allow for more fuzzy matches
-    useExtendedSearch: true, // Enable extended search for better matching
+    distance: 100,
+    useExtendedSearch: true,
   };
 
   return {
@@ -123,14 +124,15 @@ export function searchDynamicItems(
       if (hasSubjectMatch) {
         score += 20; // Boost score for direct subject matches
       }
-      // Boost for higher year levels
-      const yearMatch = /^Year (\d+)/i.exec(item.metadata?.subjectName || "");
-      if (yearMatch) {
-        const yearNum = parseInt(yearMatch[1], 10);
-        if (!isNaN(yearNum)) {
-          score += yearNum; // Boost by year number
-        }
+
+      // Boost for active subjects
+      if (item.metadata?.isActive) {
+        score += 15; // Boost for active subjects
       }
+
+      // Boost for year level
+      const yearLevel = item.metadata?.yearLevel || 0;
+      score += yearLevel; // Add year level to score
     }
 
     const ageInDays = (now - item.dateAdded) / (1000 * 60 * 60 * 24);


### PR DESCRIPTION
### TLDR: Index's and searches through subjects to open their course or assessment page

**_notes_**:

- Uses SEQTA subject API to get the direct response
- Own index job that's every page load (probably a bit excessive but it only does it if it detects new subjects)
- If it cant start the job the pre loaded ones DON;T load (probably need a better implementation to call `loadDynamicItems`)

**_Demo_**


https://github.com/user-attachments/assets/2a4a3fd2-99af-4503-99f9-84e2732648ac




