### PR TITLE
Remove chunk size warning

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -78,6 +78,7 @@ export default defineConfig(({ command }) => ({
     emptyOutDir: false,
     minify: true,
     //sourcemap: sourcemap,
+    chunkSizeWarningLimit: 4000,
     rollupOptions: {
       input: {
         settings: join(__dirname, "src", "interface", "index.html"),


### PR DESCRIPTION
I removed the following annoying warning from appearing in cmd prompt

![image](https://github.com/user-attachments/assets/1fb4f2b6-96fe-4d22-889b-ec73b98e9dc5)

We don't need the warning right, it's fine to remove?