### PR TITLE
Fixed flickering of new icon

### DIFF
--- a/src/css/injected.scss
+++ b/src/css/injected.scss
@@ -370,7 +370,7 @@ ul.magicDelete > li.deleting {
   margin-top: -2px;
 }
 #menu li {
-  transition: color 0.1s;
+  transition: color 0.1s, background 0.1s;
 }
 #menu section > label {
   align-items: center;

--- a/src/css/injected.scss
+++ b/src/css/injected.scss
@@ -370,7 +370,7 @@ ul.magicDelete > li.deleting {
   margin-top: -2px;
 }
 #menu li {
-  transition: color 0.2s, background 0.2s;
+  transition: color 0.01s, background 0.01s;
 }
 #menu section > label {
   align-items: center;

--- a/src/css/injected.scss
+++ b/src/css/injected.scss
@@ -369,6 +369,9 @@ ul.magicDelete > li.deleting {
   top: 71.5px;
   margin-top: -2px;
 }
+#menu li {
+  transition: color 0.2s, background 0.2s;
+}
 #menu section > label {
   align-items: center;
   box-sizing: border-box;

--- a/src/css/injected.scss
+++ b/src/css/injected.scss
@@ -370,7 +370,7 @@ ul.magicDelete > li.deleting {
   margin-top: -2px;
 }
 #menu li {
-  transition: color 0.01s, background 0.01s;
+  transition: color 0.05s, background 0.05s;
 }
 #menu section > label {
   align-items: center;

--- a/src/css/injected.scss
+++ b/src/css/injected.scss
@@ -370,7 +370,7 @@ ul.magicDelete > li.deleting {
   margin-top: -2px;
 }
 #menu li {
-  transition: color 0.05s, background 0.05s;
+  transition: color 0.1s;
 }
 #menu section > label {
   align-items: center;

--- a/src/seqta/ui/AddBetterSEQTAElements.ts
+++ b/src/seqta/ui/AddBetterSEQTAElements.ts
@@ -229,11 +229,6 @@ newsbutton?.addEventListener("click", function () {
     !newsbutton.classList.contains("draggable") &&
     !newsbutton.classList.contains("active")
   ) {
-    // Remove 'active' from all sidebar items
-    document.querySelectorAll("#menu li.active").forEach(li => li.classList.remove("active"));
-    // Instantly set 'active' on the news button
-    newsbutton.classList.add("active");
-    // Now load the news page
     SendNewsPage();
   }
 });

--- a/src/seqta/ui/AddBetterSEQTAElements.ts
+++ b/src/seqta/ui/AddBetterSEQTAElements.ts
@@ -224,14 +224,19 @@ function setupEventListeners() {
     }
   });
 
-  newsbutton?.addEventListener("click", function () {
-    if (
-      !newsbutton.classList.contains("draggable") &&
-      !newsbutton.classList.contains("active")
-    ) {
-      SendNewsPage();
-    }
-  });
+newsbutton?.addEventListener("click", function () {
+  if (
+    !newsbutton.classList.contains("draggable") &&
+    !newsbutton.classList.contains("active")
+  ) {
+    // Remove 'active' from all sidebar items
+    document.querySelectorAll("#menu li.active").forEach(li => li.classList.remove("active"));
+    // Instantly set 'active' on the news button
+    newsbutton.classList.add("active");
+    // Now load the news page
+    SendNewsPage();
+  }
+});
 
   menuCover?.addEventListener("click", function () {
     location.href = "../#?page=/home";


### PR DESCRIPTION
Not sure if anyone is aware, but as shown in the video when switching to the news tab the icon flickers for about half a second between black and white.


https://github.com/user-attachments/assets/c4463133-ca52-4d2d-b564-eb71cc09ef20

I added half a second of transition which _did_ fix it properly, but there may be a better way.
