### PR TITLE
Fix - News page icon flickers

### DIFF
--- a/src/css/injected.scss
+++ b/src/css/injected.scss
@@ -457,7 +457,7 @@ ul.magicDelete > li.deleting {
   font-size: 16px;
 }
 #menu li {
-  transition: color 0.1s, background 0.1s;
+  transition: color 0.2s, background 0.2s;
 }
 #userActions {
   display: none;

--- a/src/css/injected.scss
+++ b/src/css/injected.scss
@@ -457,7 +457,7 @@ ul.magicDelete > li.deleting {
   font-size: 16px;
 }
 #menu li {
-  transition: color 0.2s, background 0.2s;
+  transition: color 0.1s, background 0.1s;
 }
 #userActions {
   display: none;

--- a/src/css/injected.scss
+++ b/src/css/injected.scss
@@ -456,6 +456,9 @@ ul.magicDelete > li.deleting {
   text-transform: none;
   font-size: 16px;
 }
+#menu li {
+  transition: color 0.2s, background 0.2s;
+}
 #userActions {
   display: none;
 }


### PR DESCRIPTION
Not sure if anyone is aware, but when clicking on the news page icon it flickers briefly between black and white


https://github.com/user-attachments/assets/274af7f7-aa26-436a-91f6-2fce18e3a8fc

Unfortunately the video does not show it well for some reason, so better to look in real life
I _did_ fix this by adding a 0.2 second transition, but there might be a better way